### PR TITLE
Updated EZS.UseNameColors

### DIFF
--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -154,9 +154,11 @@ hook.Add( "ScoreboardShow", "EasyScoreboard_Show", EZS_Do )
 
 local function AddNameColors( ply )
 	local userGroup = ply:GetNWString( "usergroup" )
-	if EZS.Colors[userGroup] and EZS.UseNameColors then
-		if EZS.Colors[userGroup] == "rainbow" then return color_white end
-		return EZS.Colors[userGroup]
-	else return color_white end
+	if EZS.UseNameColors then
+		if EZS.Colors[userGroup] then
+			if EZS.Colors[userGroup] == "rainbow" then return color_white end
+			return EZS.Colors[userGroup]
+		else return color_white end
+	end
 end
 hook.Add( "TTTScoreboardColorForPlayer", "EasyScoreboard_NameColors", AddNameColors )


### PR DESCRIPTION
Now if EZS.UseNameColors is set to false, it will use the default name coloring by TTT (admins names are yellow, everyone else is white).
