### PR TITLE
Add an option to Sort by Rank

### DIFF
--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -294,7 +294,7 @@ function EZS.AddRankLabel( sb )
 		return rank.name or ""
 	end, EZS.ColumnWidth )
 
-	if EZS.SortByRank then
+	if EZS.SortByRank and ulx then --This relies on ULX/ULib functions
 		sb:AddFakeColumn( EZS.CreateRankLabel.enabled and EZS.CreateRankLabel.text or "Rank", nil, nil, "rank", function(ply1, ply2)
 			if ply1:CheckGroup(ply2:GetUserGroup()) then
 				if ply1:IsUserGroup(ply2:GetUserGroup()) then

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -293,6 +293,7 @@ function EZS.AddRankLabel( sb )
 		if ov_name then return ov_name end
 		return rank.name or ""
 	end, EZS.ColumnWidth, "rank", function(ply1, ply2)
+		if not EZS.SortByRank then return 0 end
 		if ply1:CheckGroup(ply2:GetUserGroup()) then
 			if ply1:IsUserGroup(ply2:GetUserGroup()) then
 				return 0 --Sorts by username automatically if returned 0

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -292,26 +292,22 @@ function EZS.AddRankLabel( sb )
 
 		if ov_name then return ov_name end
 		return rank.name or ""
-	end, EZS.ColumnWidth )
-
-	if EZS.SortByRank and ulx then --This relies on ULX/ULib functions
-		sb:AddFakeColumn( EZS.CreateRankLabel.enabled and EZS.CreateRankLabel.text or "Rank", nil, nil, "rank", function(ply1, ply2)
-			if ply1:CheckGroup(ply2:GetUserGroup()) then
-				if ply1:IsUserGroup(ply2:GetUserGroup()) then
-					return 0 --Sorts by username automatically if returned 0
-				end
+	end, EZS.ColumnWidth, "rank", function(ply1, ply2)
+		if ply1:CheckGroup(ply2:GetUserGroup()) then
+			if ply1:IsUserGroup(ply2:GetUserGroup()) then
+				return 0 --Sorts by username automatically if returned 0
+			end
+			return 1
+		end
+		if not ply2:CheckGroup(ply1:GetUserGroup()) then
+			--If neither group inherits the other, sort the non-linear groups alphabetically
+			if string.lower(EZS.GetRank(ply1)) > string.lower(EZS.GetRank(ply2)) then
 				return 1
 			end
-			if not ply2:CheckGroup(ply1:GetUserGroup()) then
-				--If neither group inherits the other, sort the non-linear groups alphabetically
-				if string.lower(EZS.GetRank(ply1)) > string.lower(EZS.GetRank(ply2)) then
-					return 1
-				end
-			end
-			return -1
-		end)
-	end
-	
+		end
+		return -1
+	end))
+
 	if EZS.FixedIcon then
 		sb:AddColumn("", function( ply, label )
 			local rank = EZS.GetRank( ply )

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -21,7 +21,7 @@ EZS.CreateRankLabel = { enabled = true, text = "Rank" }
 -- what to show when the player doesnt have an entry
 EZS.DefaultLabel = ""
 
--- create a button to sort the scoreboard by users' ranks
+-- Allow clicking on the "Rank" column title to sort players by rank from highest to lowest (or inverted)
 EZS.SortByRank = true
 
 -- sadly there is no way to shift the background bar over as TTT draws it manually :c

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -21,6 +21,9 @@ EZS.CreateRankLabel = { enabled = true, text = "Rank" }
 -- what to show when the player doesnt have an entry
 EZS.DefaultLabel = ""
 
+-- create a button to sort the scoreboard by useres ranks
+EZS.SortByRank = true
+
 -- sadly there is no way to shift the background bar over as TTT draws it manually :c
 EZS.HideBackground = false
 
@@ -291,6 +294,24 @@ function EZS.AddRankLabel( sb )
 		return rank.name or ""
 	end, EZS.ColumnWidth )
 
+	if EZS.SortByRank then
+		sb:AddFakeColumn( EZS.CreateRankLabel.enabled and EZS.CreateRankLabel.text or "Rank", nil, nil, "rank", function(ply1, ply2)
+			if ply1:CheckGroup(ply2:GetUserGroup()) then
+				if ply1:IsUserGroup(ply2:GetUserGroup()) then
+					return 0 --Sorts by username automatically if returned 0
+				end
+				return 1
+			end
+			if not ply2:CheckGroup(ply1:GetUserGroup()) then
+				--If neither group inherits the other, sort the non-linear groups alphabetically
+				if string.lower(EZS.GetRank(ply1)) > string.lower(EZS.GetRank(ply2)) then
+					return 1
+				end
+			end
+			return -1
+		end)
+	end
+	
 	if EZS.FixedIcon then
 		sb:AddColumn("", function( ply, label )
 			local rank = EZS.GetRank( ply )

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -306,7 +306,7 @@ function EZS.AddRankLabel( sb )
 			end
 		end
 		return -1
-	end))
+	end)
 
 	if EZS.FixedIcon then
 		sb:AddColumn("", function( ply, label )

--- a/lua/autorun/client/TTT_EasyScoreboard.lua
+++ b/lua/autorun/client/TTT_EasyScoreboard.lua
@@ -21,7 +21,7 @@ EZS.CreateRankLabel = { enabled = true, text = "Rank" }
 -- what to show when the player doesnt have an entry
 EZS.DefaultLabel = ""
 
--- create a button to sort the scoreboard by useres ranks
+-- create a button to sort the scoreboard by users' ranks
 EZS.SortByRank = true
 
 -- sadly there is no way to shift the background bar over as TTT draws it manually :c


### PR DESCRIPTION
One of the latest TTT updates added some buttons to sort the scoreboard by users' names and roles (and some other stuff but only in commands). It's pretty easy to add the ability to sort by ranks (currently this only has support for ULX), so you may as well add a config option to allow people to.